### PR TITLE
Fix News search bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ Ticker,Quantity
 AAPL,10
 TSLA,5
 MSFT,8
+```

--- a/pages/5_News_and_Sentiment.py
+++ b/pages/5_News_and_Sentiment.py
@@ -1,7 +1,6 @@
 import streamlit as st
 import requests
 from textblob import TextBlob
-import pandas as pd
 
 st.title("📰 News & Sentiment")
 st.markdown("Get the latest news and sentiment analysis for any company, stock, or keyword.")
@@ -12,10 +11,15 @@ query = st.text_input("Search for stock or keyword (e.g., AAPL, Bitcoin, Microso
 
 if query:
     st.info(f"🔍 Fetching news for: {query}")
-    url = f"https://newsdata.io/api/1/news?apikey={API_KEY}&q={query}&language=en&category=business"
+    params = {
+        "apikey": API_KEY,
+        "q": query,
+        "language": "en",
+        "category": "business",
+    }
 
     try:
-        response = requests.get(url)
+        response = requests.get("https://newsdata.io/api/1/news", params=params)
         data = response.json()
 
         if "results" not in data:


### PR DESCRIPTION
## Summary
- encode query params when fetching news articles so spaces work
- close CSV example code block in README

## Testing
- `flake8 .`
- `python -m py_compile app.py pages/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6878018c572883309249b4c33c22e410